### PR TITLE
[ci skip] adding user @jgrss

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @RyanHackney @mxr-conda @ndmaxar @rluria14
+* @jgrss @RyanHackney @mxr-conda @ndmaxar @rluria14

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,6 +69,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - jgrss
     - mxr-conda
     - rluria14
     - ndmaxar


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @jgrss as instructed in #20.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #20